### PR TITLE
Feat: Chip 컴포넌트 구현

### DIFF
--- a/apps/web/src/shared/components/chip/chip.css.ts
+++ b/apps/web/src/shared/components/chip/chip.css.ts
@@ -1,0 +1,51 @@
+import { recipe } from "@vanilla-extract/recipes";
+import { vars } from "@/shared/styles/theme.css";
+import { typo } from "@/shared/styles/typography.css";
+import { color, bgColor } from "@/shared/styles/color.css";
+
+export const chip = recipe({
+  base: {
+    border: "none",
+    cursor: "pointer",
+    overflow: "hidden",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "0.8rem",
+    whiteSpace: "nowrap",
+    userSelect: "none",
+    WebkitTapHighlightColor: "transparent",
+
+    selectors: {
+      "&:disabled": {
+        cursor: "not-allowed",
+        opacity: 0.5,
+      },
+      "&:focus-visible": {
+        outline: `0.2rem solid ${vars.color.main[200]}`,
+        outlineOffset: "0.2rem",
+      },
+    },
+  },
+
+  variants: {
+    shape: {
+      pill: { padding: "1.2rem 2.4rem", borderRadius: vars.radius.r48 },
+      square: { padding: "0.8rem 1.6rem", borderRadius: vars.radius.r12 },
+    },
+
+    state: {
+      default: [
+        typo.body3.medium,
+        color["grayscale-500"],
+        bgColor["grayscale-50"],
+      ],
+      active: [typo.body3.semibold, color["main-500"], bgColor["main-100"]],
+    },
+  },
+
+  defaultVariants: {
+    shape: "pill",
+    state: "default",
+  },
+});

--- a/apps/web/src/shared/components/chip/chip.stories.tsx
+++ b/apps/web/src/shared/components/chip/chip.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Chip from "@/shared/components/chip/chip";
+
+const meta = {
+  title: "Shared/Chip",
+  component: Chip,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          "Chip은 텍스트 라벨을 가진 버튼형 UI입니다.",
+          "",
+          "- shape: pill | square",
+          "- state: default | active (active면 aria-pressed=true)",
+          "- disabled/onClick/type 지원",
+        ].join("\n"),
+      },
+    },
+  },
+  args: {
+    label: "Text",
+    shape: "pill",
+    state: "default",
+    disabled: false,
+    type: "button",
+    ariaLabel: "chip",
+  },
+  argTypes: {
+    label: { control: "text" },
+    shape: { control: "inline-radio", options: ["pill", "square"] },
+    state: { control: "inline-radio", options: ["default", "active"] },
+    disabled: { control: "boolean" },
+    type: { control: "inline-radio", options: ["button", "submit", "reset"] },
+    ariaLabel: { control: "text" },
+    onClick: { action: "click" },
+    className: { control: false },
+  },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  name: "Playground",
+};
+
+export const Default: Story = {
+  name: "Default",
+};
+
+export const Active: Story = {
+  name: "Active",
+  args: {
+    state: "active",
+  },
+};
+
+export const SquareDefault: Story = {
+  name: "Square / Default",
+  args: {
+    shape: "square",
+    state: "default",
+  },
+};
+
+export const SquareActive: Story = {
+  name: "Square / Active",
+  args: {
+    shape: "square",
+    state: "active",
+  },
+};
+
+export const Disabled: Story = {
+  name: "Disabled",
+  args: {
+    disabled: true,
+  },
+};

--- a/apps/web/src/shared/components/chip/chip.tsx
+++ b/apps/web/src/shared/components/chip/chip.tsx
@@ -1,0 +1,40 @@
+import clsx from "clsx";
+import type { ButtonHTMLAttributes } from "react";
+import * as s from "@/shared/components/chip/chip.css";
+
+type ChipProps = {
+  label: string;
+  shape?: "pill" | "square";
+  state?: "default" | "active";
+  className?: string;
+  ariaLabel?: string;
+} & Pick<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "disabled" | "onClick" | "type"
+>;
+
+export const Chip = ({
+  label,
+  shape = "pill",
+  state = "default",
+  disabled = false,
+  onClick,
+  type = "button",
+  className,
+  ariaLabel,
+}: ChipProps) => {
+  return (
+    <button
+      type={type}
+      className={clsx(s.chip({ shape, state }), className)}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel ?? label}
+      aria-pressed={state === "active"}
+    >
+      <span>{label}</span>
+    </button>
+  );
+};
+
+export default Chip;


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

## 🔗 관련 이슈

Closes #42

## 💡 작업 내용

이번 PR에서는 공통 UI로 재사용할 수 있는 Chip 컴포넌트를 구현했습니다. Figma에서 제공된 4가지 케이스(기본/활성 × pill/square)를 모두 커버할 수 있도록 shape/state 기반으로 스타일을 분리했고, 라벨은 body3 타이포를 공통으로 사용하도록 맞췄습니다.
스토리북에 기본/활성/모양/disabled/긴 라벨 등 주요 시나리오를 추가해 사용처에서 쉽게 확인할 수 있도록 했습니다.

### 사용 예시

```tsx
      <Chip label="Text" />
      <Chip label="Text" state="active" />
      <Chip label="Text" shape="square" />
      <Chip label="Text" shape="square" state="active" />
```

## 📸 Screenshots or Video(선택)
<img width="686" height="150" alt="image" src="https://github.com/user-attachments/assets/326d6284-e171-419b-b580-5a8608137f94" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Chip 컴포넌트 추가: 두 가지 모양 (원형, 정사각형)과 두 가지 상태 (기본, 활성)를 지원합니다.
  * 접근성 기능 포함: ARIA 속성과 장애인 상태 지원.
  * 클릭 이벤트 처리 및 커스터마이징 가능한 스타일 지원.
  * Storybook 문서화: 다양한 사용 사례를 보여주는 대화형 예제 제공.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->