### PR TITLE
Refactor: Button 컴포넌트 확장

### DIFF
--- a/apps/web/src/shared/components/button/button/button.css.ts
+++ b/apps/web/src/shared/components/button/button/button.css.ts
@@ -1,16 +1,22 @@
+import { style, styleVariants } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
-import { createVar, style } from "@vanilla-extract/css";
+
 import { vars } from "@/shared/styles/theme.css";
 import { typo } from "@/shared/styles/typography.css";
-
-export const gapVar = createVar();
-export const paddingXVar = createVar();
-export const paddingYVar = createVar();
-export const radiusVar = createVar();
+import { bgColor, color } from "@/shared/styles/color.css";
 
 export const icon = style({
   flexShrink: 0,
   display: "block",
+});
+
+export const tone = styleVariants({
+  surface: [bgColor["grayscale-50"], color["grayscale-700"]],
+  default: [bgColor["grayscale-100"], color["grayscale-800"]],
+  dark: [bgColor["grayscale-900"], color["grayscale-0"]],
+  kakao: [bgColor["login-kakao"], color["grayscale-900"]],
+  complete: [bgColor["main-500"], color["grayscale-0"]],
+  disabled: [bgColor["grayscale-100"], color["grayscale-500"]],
 });
 
 export const button = recipe({
@@ -21,29 +27,16 @@ export const button = recipe({
     alignItems: "center",
     justifyContent: "center",
     flexShrink: 0,
-    gap: gapVar,
-    padding: `${paddingYVar} ${paddingXVar}`,
-    borderRadius: radiusVar,
+
     transition:
       "background-color 180ms cubic-bezier(0.2, 0, 0, 1), color 180ms cubic-bezier(0.2, 0, 0, 1)",
 
-    vars: {
-      [gapVar]: "0.8rem",
-      [paddingXVar]: "1.2rem",
-      [paddingYVar]: "0.8rem",
-      [radiusVar]: vars.radius.r12,
-    },
-
     selectors: {
-      "&:disabled": {
-        cursor: "not-allowed",
-      },
+      "&:disabled": { cursor: "not-allowed" },
     },
 
     "@media": {
-      "(prefers-reduced-motion: reduce)": {
-        transition: "none",
-      },
+      "(prefers-reduced-motion: reduce)": { transition: "none" },
     },
   },
 
@@ -51,48 +44,33 @@ export const button = recipe({
     size: {
       "32": {
         minHeight: "3.2rem",
-        vars: {
-          [paddingYVar]: "0.6rem",
-          [paddingXVar]: "1.2rem",
-          [radiusVar]: vars.radius.r8,
-          [gapVar]: "0.6rem",
-        },
+        padding: "0.6rem 1.2rem",
+        borderRadius: vars.radius.r8,
+        gap: "0.6rem",
       },
       "40": {
         minHeight: "4.0rem",
-        vars: {
-          [paddingYVar]: "0.8rem",
-          [paddingXVar]: "1.2rem",
-          [radiusVar]: vars.radius.r8,
-          [gapVar]: "0.8rem",
-        },
+        padding: "0.8rem 1.2rem",
+        borderRadius: vars.radius.r8,
+        gap: "0.8rem",
       },
       "48": {
         minHeight: "4.8rem",
-        vars: {
-          [paddingYVar]: "0.8rem",
-          [paddingXVar]: "1.2rem",
-          [radiusVar]: vars.radius.r12,
-          [gapVar]: "0.8rem",
-        },
+        padding: "0.8rem 1.2rem",
+        borderRadius: vars.radius.r12,
+        gap: "0.8rem",
       },
       "56": {
         minHeight: "6.0rem",
-        vars: {
-          [paddingYVar]: "0.8rem",
-          [paddingXVar]: "1.2rem",
-          [radiusVar]: vars.radius.r12,
-          [gapVar]: "0.8rem",
-        },
+        padding: "0.8rem 1.2rem",
+        borderRadius: vars.radius.r12,
+        gap: "0.8rem",
       },
       "60": {
         minHeight: "6.0rem",
-        vars: {
-          [paddingYVar]: "0.8rem",
-          [paddingXVar]: "1.2rem",
-          [radiusVar]: vars.radius.r12,
-          [gapVar]: "0.8rem",
-        },
+        padding: "0.8rem 1.2rem",
+        borderRadius: vars.radius.r12,
+        gap: "0.8rem",
       },
     },
 

--- a/apps/web/src/shared/components/button/button/button.tsx
+++ b/apps/web/src/shared/components/button/button/button.tsx
@@ -1,62 +1,29 @@
-import type { ButtonHTMLAttributes } from "react";
-import React from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 import clsx from "clsx";
 import * as styles from "@/shared/components/button/button/button.css";
 import Icon from "@/shared/components/icon/icon";
 import type { IconProps } from "@/shared/components/icon/icon";
-import { bgColor, color } from "@/shared/styles/color.css";
-import { vars } from "@/shared/styles/theme.css";
-import { assignInlineVars } from "@vanilla-extract/dynamic";
 
 export type ButtonSize = "32" | "40" | "48" | "56" | "60";
-export type ButtonTone = "surface" | "default" | "dark" | "kakao" | "complete";
+export type ButtonTone =
+  | "surface"
+  | "default"
+  | "dark"
+  | "kakao"
+  | "complete"
+  | "none";
 export type ButtonIconPosition = "left" | "right";
 
-const TONE_BG: Record<ButtonTone, keyof typeof bgColor> = {
-  surface: "grayscale-50",
-  default: "grayscale-100",
-  dark: "grayscale-900",
-  kakao: "login-kakao",
-  complete: "main-500",
-};
-
-const TONE_FG: Record<ButtonTone, keyof typeof color> = {
-  surface: "grayscale-700",
-  default: "grayscale-800",
-  dark: "grayscale-0",
-  kakao: "grayscale-900",
-  complete: "grayscale-0",
-};
-
 type ButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> & {
-  label: React.ReactNode;
+  label: ReactNode;
   size?: ButtonSize;
   tone?: ButtonTone;
   fullWidth?: boolean;
-
   icon?: IconProps["name"];
-  /** left | right */
   iconPosition?: ButtonIconPosition;
-  /** rem 단위 숫자 */
   iconSize?: number;
-  /** bgColor 토큰 키로 직접 오버라이드 */
-  bgColorKey?: keyof typeof bgColor;
-  /** color 토큰 키로 직접 오버라이드 */
-  textColorKey?: keyof typeof color;
-  /** label에 적용할 typo className (예: typo.body2.semibold) */
-  labelTypo?: string;
-  /** rem 단위 숫자: 아이콘-텍스트 사이 갭 */
-  gap?: number;
-  /** rem 단위 숫자 */
-  paddingX?: number;
-  /** rem 단위 숫자 */
-  paddingY?: number;
-  /** theme radius 키로 오버라이드 (px 토큰) */
-  radius?: keyof typeof vars.radius;
-  classNames?: {
-    icon?: string;
-    label?: string;
-  };
+  labelClassName?: string;
+  iconClassName?: string;
 };
 
 export const Button = ({
@@ -67,54 +34,34 @@ export const Button = ({
   icon,
   iconPosition = "left",
   iconSize = 2.4,
-  bgColorKey,
-  textColorKey,
-  labelTypo,
-  gap,
-  paddingX,
-  paddingY,
-  radius,
   className,
-  classNames,
+  labelClassName,
+  iconClassName,
   type = "button",
   disabled,
   ...rest
 }: ButtonProps) => {
-  const isDisabled = Boolean(disabled);
-
-  const resolvedBgKey: keyof typeof bgColor = isDisabled
-    ? "grayscale-100"
-    : (bgColorKey ?? TONE_BG[tone]);
-
-  const resolvedFgKey: keyof typeof color = isDisabled
-    ? "grayscale-500"
-    : (textColorKey ?? TONE_FG[tone]);
-
-  const inlineVars = assignInlineVars({
-    ...(gap != null ? { [styles.gapVar]: `${gap}rem` } : {}),
-    ...(paddingX != null ? { [styles.paddingXVar]: `${paddingX}rem` } : {}),
-    ...(paddingY != null ? { [styles.paddingYVar]: `${paddingY}rem` } : {}),
-    ...(radius != null ? { [styles.radiusVar]: vars.radius[radius] } : {}),
-  });
-
   const iconNode = icon ? (
     <Icon
       name={icon}
       size={iconSize}
-      className={clsx(styles.icon, classNames?.icon)}
+      className={clsx(styles.icon, iconClassName)}
     />
   ) : null;
+
+  const toneClassName = tone === "none" ? null : styles.tone[tone];
+  const disabledToneClassName =
+    tone === "none" ? null : disabled && styles.tone.disabled;
 
   return (
     <button
       type={type}
       disabled={disabled}
-      style={inlineVars}
       className={clsx(
         styles.button({ size, fullWidth }),
-        bgColor[resolvedBgKey],
-        color[resolvedFgKey],
-        className
+        toneClassName,
+        className,
+        disabledToneClassName
       )}
       {...rest}
     >
@@ -123,8 +70,8 @@ export const Button = ({
       <span
         className={clsx(
           styles.labelBase,
-          labelTypo ?? styles.labelSizeTypo({ size }),
-          classNames?.label
+          styles.labelSizeTypo({ size }),
+          labelClassName
         )}
       >
         {label}


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

## 🔗 관련 이슈

Closes #77 

## 💡 작업 내용

처음에 피그마 컴포넌트에 나와있는 버튼 4가지 variant를 기반으로 개발을 진행했는데 전체 페이지 퍼블리싱하면서 버튼 케이스가 상당히,, 많아져서 이번 작업을 진행하게 되었어요!

기존 `Button` 컴포넌트는 `tone/size/fullWidth` 같은 variant 기반 사용을 전제로 했고, 특정 화면에서 버튼의 `bgColor`, `color`, `typo`, `gap`, `padding`, `radius` 등을 바꾸려면 컴포넌트 props를 계속 확장해야 했습니다. 이 방식은 버튼 API가 빠르게 비대해지고, 화면 단위의 스타일 조합을 만들기 어려운 문제가 있었습니다.

이번 변경에서는 버튼을 스타일 결정과 기능으로 분리했습니다. `Button`은 클릭/disabled/아이콘/라벨/사이즈 같은 **구조와 기능**에 집중하고, 색상/타이포/레이아웃(패딩/갭/라운드 등)은 **상위에서 vanilla-extract className 조합으로 자유롭게 확장**할 수 있도록 했습니다. 따라서 화면별 디자인 요구가 생겨도 Button의 props를 계속 늘리지 않고, 해당 페이지/컴포넌트의 `.css.ts`에서 재사용 가능한 스타일 프리셋을 만들어 적용할 수 있습니다.

또한 tone이 항상 필요하지 않은 케이스(완전히 커스텀한 버튼)도 지원하기 위해 `tone="none"`을 추가했습니다. 이를 통해 `bgColor/color` 토큰을 상위에서 직접 조합할 때 내부 tone 스타일과의 충돌을 피할 수 있습니다.

### 사용 가이드

* 기본 톤을 쓰고 싶으면: `tone="surface" | "default" | ...` 사용
* 완전 커스텀 스타일(색/레이아웃 포함)을 쓰고 싶으면 `className`에 `bgColor`, `color`, 그리고 커스텀 레이아웃 스타일을 조합해서 사용

### 예시 코드

```tsx
import { Button } from "@/shared/components/button/button/button";
import { bgColor, color } from "@/shared/styles/color.css";
import { typo } from "@/shared/styles/typography.css";

import * as s from "@/app/wrong/create/create.css";
import clsx from "clsx";

const Page = () => {
  return (
    <div
      style={{
        padding: "4rem",
        display: "flex",
        flexDirection: "column",
        gap: "2rem",
      }}
    >
      <Button
        label="완료"
        className={s.completeBtn}
        labelClassName={typo.body1.bold}
        icon="file"
        iconSize={2}
      />

      <Button
        label="경고"
        className={clsx(bgColor["grayscale-900"], color["grayscale-0"])}
      />
    </div>
  );
};
```

```ts
export default Page;
import { style } from "@vanilla-extract/css";
import { bgColor, color } from "@/shared/styles/color.css";
import { typo } from "@/shared/styles/typography.css";
import { vars } from "@/shared/styles/theme.css";

export const completeBtn = style([
  bgColor["main-500"],
  color["grayscale-0"],
  {
    borderRadius: vars.radius.r20,
    gap: "1rem",
    padding: "0 1.4rem",
  },
]);
```


## 💬 원하는 리뷰 방식(선택)

기존에 버튼 커스텀을 위해 `gap/padding/radius` 등 레이아웃 props를 계속 추가하던 흐름을.. 이번 변경으로 페이지 전용 프리셋 스타일로 흡수할 수 있게 되었습니다. 이후에도 버튼 변형이 필요하면 Button 자체를 확장하기보다 해당 화면의 `.css.ts`에서 프리셋을 추가하는 방향으로 진행하면 좋을 것 같아요!

## 📸 Screenshots or Video(선택)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/403fb9b1-4c00-43e0-a90a-629160daaecb" />
