### PR TITLE
Style: (QA/1) textfield UI 및 오답 공백처리 수정

### DIFF
--- a/apps/web/src/app/wrong/[id]/edit/components/solution-section/solution-section.tsx
+++ b/apps/web/src/app/wrong/[id]/edit/components/solution-section/solution-section.tsx
@@ -12,11 +12,11 @@ export const SolutionSection = ({
 }: SolutionSectionProps) => {
   return (
     <section className={styles.section}>
-      <h2 className={styles.title}>풀이</h2>
+      <h2 className={styles.title}>메모</h2>
       <div className={styles.textField}>
         <TextField
           heightSize="lg"
-          placeholder="풀이를 입력하세요"
+          placeholder="메모를 입력하세요"
           value={solution}
           onChange={(e) => onSolutionChange(e.target.value)}
           fullWidth

--- a/apps/web/src/app/wrong/[id]/edit/components/wrong-edit-form/wrong-edit-form.tsx
+++ b/apps/web/src/app/wrong/[id]/edit/components/wrong-edit-form/wrong-edit-form.tsx
@@ -60,7 +60,11 @@ export const WrongEditForm = () => {
             tone="dark"
             label="수정 완료"
             size="48"
-            disabled={isPending}
+            disabled={
+              isPending ||
+              (questionType === "subjective" && answerText.trim() === "") ||
+              (questionType === "objective" && selectedNumber === null)
+            }
           />
         </div>
       </div>

--- a/apps/web/src/shared/components/text-field/text-field.css.ts
+++ b/apps/web/src/shared/components/text-field/text-field.css.ts
@@ -68,7 +68,7 @@ export const textareaWrapper = recipe({
     },
     size: {
       lg: { minHeight: "17.6rem" },
-      md: { minHeight: "1.6rem" },
+      md: { minHeight: "2.4rem" },
     },
   },
   defaultVariants: {
@@ -100,10 +100,12 @@ export const textarea = recipe({
       outline: "none",
       flex: 1,
       width: "100%",
+      minHeight: "2.4rem",
       border: "none",
       background: "transparent",
       resize: "none",
       fontFamily: "inherit",
+      fieldSizing: "content",
     },
   ],
   variants: {

--- a/apps/web/src/shared/components/text-field/text-field.tsx
+++ b/apps/web/src/shared/components/text-field/text-field.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import clsx from "clsx";
 import * as styles from "./text-field.css";
 
@@ -19,6 +19,14 @@ export interface TextFieldProps extends Omit<
   focusEffect?: boolean;
 }
 
+const MIN_TEXTAREA_HEIGHT = 24;
+
+const adjustTextareaHeight = (el: HTMLTextAreaElement | null) => {
+  if (!el || el.getAttribute("data-fixed-height") === "true") return;
+  el.style.height = "auto";
+  el.style.height = `${Math.max(el.scrollHeight, MIN_TEXTAREA_HEIGHT)}px`;
+};
+
 export const TextField = ({
   variant = "default",
   prefixPosition = "left",
@@ -29,8 +37,23 @@ export const TextField = ({
   size = "body3",
   heightSize = "md",
   focusEffect = true,
+  value,
+  onInput,
   ...rest
 }: TextFieldProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isPlain = variant === "plain";
+
+  useEffect(() => {
+    if (isPlain) return;
+    adjustTextareaHeight(textareaRef.current);
+  }, [value, isPlain]);
+
+  const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+    if (!isPlain) adjustTextareaHeight(e.currentTarget);
+    onInput?.(e);
+  };
+
   return (
     <div className={clsx(styles.container({ fullWidth, focusEffect }))}>
       <div
@@ -38,7 +61,7 @@ export const TextField = ({
           styles.textareaWrapper({
             variant,
             disabled,
-            size: variant === "plain" ? undefined : heightSize,
+            size: isPlain ? undefined : heightSize,
             direction,
           })
         )}
@@ -50,6 +73,7 @@ export const TextField = ({
         )}
 
         <textarea
+          ref={textareaRef}
           className={clsx(
             styles.textarea({
               variant,
@@ -58,6 +82,9 @@ export const TextField = ({
             })
           )}
           disabled={disabled}
+          value={value}
+          onInput={handleInput}
+          data-fixed-height={isPlain ? "true" : undefined}
           {...rest}
         />
       </div>


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

## 🔗 관련 이슈

Closes #114 

## 💡 작업 내용
- 기존 text-field 컴포넌트의 높이를 minHeight로 설정되어 있었는데 그러다보니 2줄 넘어가는 텍스트일 경우 첫번째 줄은 안보이고 UX적으로 별로라 판단하여 `adjustTextareaHeight`함수 바탕으로 `textarea` 요소의 실제 컨텐츠 값을 바탕으로 계산되어 UI로 보여지도록 수정했습니다.
- 오답 수정 페이지에서 풀이 > 메모 로 워딩 변경하였고, 수정완료는 `answerText`값이 공백이거나 `selectedNumber`값이 null일 경우 disabled가 되도록 처리했습니다.

## 💬 원하는 리뷰 방식(선택)
- text-field컴포넌트에서 실제 요소 컨텐츠 높이에 따라 유동적으로 커지도록 하는게 자연스러운지 의견 부탁드립니다

## 📸 Screenshots or Video(선택)

https://github.com/user-attachments/assets/a7d80d5b-8bca-44f5-b554-3f5eb4a3a85b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 폼 제출 시 입력 검증 강화: 필수 필드가 미입력일 경우 제출 버튼이 비활성화됩니다.

* **스타일 및 UI**
  * UI 텍스트 레이블 변경 ("풀이" → "메모")
  * 텍스트 영역의 크기 및 자동 조정 기능 개선으로 더 나은 입력 환경 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->