### PR TITLE
Style: 홈 카드 그래프 01 100%일 때 스타일 수정

### DIFF
--- a/apps/web/src/shared/components/bar-graph/bar-graph-01/utils/bar-graph-01.ts
+++ b/apps/web/src/shared/components/bar-graph/bar-graph-01/utils/bar-graph-01.ts
@@ -33,5 +33,6 @@ export const computeVisualPercent = (params: {
   const hi = Math.max(min, max);
 
   if (rawPercent === 0) return 0;
+  if (rawPercent === 100) return 100;
   return lo + (rawPercent / 100) * (hi - lo);
 };

--- a/apps/web/src/shared/components/card-graph/card-graph-01/card-graph-01.tsx
+++ b/apps/web/src/shared/components/card-graph/card-graph-01/card-graph-01.tsx
@@ -38,6 +38,7 @@ export const CardGraph01 = ({
   const safePercent = clamp(graphPercent, 0, 100);
   const percentLabel = `${Math.round(safePercent)}%`;
   const resolvedReplayKey = replayKey ?? pathname;
+  const isComplete = safePercent === 100;
 
   const isEmpty = registeredCount === 0;
   const isSolvedZero = solvedCount === 0;
@@ -80,10 +81,10 @@ export const CardGraph01 = ({
 
           <BarGraph01
             percent={safePercent}
-            label={resolvedGraphLabel}
+            label={isComplete ? undefined : resolvedGraphLabel}
             replayKey={resolvedReplayKey}
             showMinFillOnZero={isSolvedZero}
-            showTip={!isSolvedZero}
+            showTip={!isSolvedZero && !isComplete}
           />
         </div>
       </div>


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

## 🔗 관련 이슈

Closes #158

## 💡 작업 내용

데모데이 당일 피드백을 반영한 작업입니다~!
홈 `CardGraph01`에서 그래프 진행률이 `100%`인 경우를 별도로 처리하도록 수정했어요! 
기존에는 label과 그래프 팁 때문에 그래프를 끝까지 차지 않게 스타일을 구현했었는데, `computeVisualPercent`에서 `rawPercent === 100`인 경우 `100`을 바로 반환하도록 수정해, 완료 상태에서 그래프가 정확히 끝까지 차도록 보정했습니다.
먼저 `safePercent === 100`일 때 `isComplete` 값을 기준으로, 그래프 라벨이 노출되지 않도록 변경했습니다.
이 부분은 100%로 그래프가 채워지면서 불필요한 라벨이기 때문에 별도 처리했습니다.
추가로 그래프 팁이 노출되지 않도록 변경했어요.


### 변경 상세

#### 1. 그래프 100% 완료 상태 처리
- `CardGraph01`에 `isComplete` 조건을 추가했습니다.
- 완료 상태에서는 아래처럼 동작합니다.
  - `label={undefined}`
  - `showTip={false}`

#### 2. visual percent 계산 보정
- `computeVisualPercent`에 아래 조건을 추가했습니다.
  - `rawPercent === 100`일 때 `100` 반환
- 이를 통해 최소/최대 퍼센트 보정 로직과 별개로, 완료 상태가 시각적으로도 정확히 100%로 표현되도록 수정했습니다.

## 💬 원하는 리뷰 방식(선택)

아주 간단한 작업이지만...
- 100% 완료 상태에서 라벨/팁이 사라지는 처리 방식이 UX적으로 자연스러운지 중점적으로 봐주시면 좋겠습니다.
- `computeVisualPercent`의 예외 처리(`0`, `100`)가 그래프 전반 로직과 충돌 없는지도 함께 확인 부탁드립니다!


## 📸 Screenshots or Video(선택)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2e4d53e8-f495-4cbd-8ae9-22190d9a05cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 그래프가 100% 완료 상태에 도달할 때의 표시 로직 개선
* 완료된 그래프에서 도움말 표시 조건 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->