### PR TITLE
Feat: 스플래시 시간 단축, 오답 등록 완료 라벨 변경

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import "@/shared/styles/index.css";
 import "@/shared/styles/global.css";
-import "katex/dist/katex.min.css";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { Suspense } from "react";

--- a/apps/web/src/app/wrong/create/done/page.tsx
+++ b/apps/web/src/app/wrong/create/done/page.tsx
@@ -33,8 +33,8 @@ const WrongCreateDonePage = () => {
         />
         <Button
           tone="default"
-          label="홈으로"
-          onClick={() => router.push(ROUTES.HOME)}
+          label="문제 목록으로"
+          onClick={() => router.push(ROUTES.WRONG.ROOT)}
         />
       </div>
     </div>

--- a/apps/web/src/shared/components/splash/splash.css.ts
+++ b/apps/web/src/shared/components/splash/splash.css.ts
@@ -20,7 +20,7 @@ export const overlay = style([
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    animation: `${splashOut} 5s ease-out forwards`,
+    animation: `${splashOut} 4s ease-out forwards`,
   },
 ]);
 

--- a/apps/web/src/shared/components/splash/splash.tsx
+++ b/apps/web/src/shared/components/splash/splash.tsx
@@ -71,7 +71,7 @@ const Splash = ({ onDone }: SplashProps) => {
         autoplay
         loop={false}
         animationData={splashLottie}
-        onDOMLoaded={() => lottieRef.current?.setSpeed(1.5)}
+        onDOMLoaded={() => lottieRef.current?.setSpeed(1.7)}
         className={s.image}
       />
     </div>


### PR DESCRIPTION
<!---- 'Closes #'다음에 완료한 이슈 넘버를 작성해 주세요. ex) Closes #4 !-->

## 🔗 관련 이슈

Closes #177

## 💡 작업 내용

스플래시 시간을 단축하고 오답 등록 완료 라벨을 [홈으로]에서 [문제 목록으로]로 변경했어요.
오답 등록 완료 화면에서 기존 HOME에서 WRONG.ROOT로 이동 경로를 변경했어요.
그리고 apps/web/src/app/layout.tsx에 임포트 오류나는 게 있었는데 불필요한 부분이라서 삭제했습니다!!

## 💬 원하는 리뷰 방식(선택)

## 📸 Screenshots or Video(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **사용자 인터페이스**
  * 문제 생성 완료 화면에서 버튼의 텍스트 및 이동 위치가 업데이트되었습니다.
  * 앱 시작 시 스플래시 화면 애니메이션이 더 빠르게 재생됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Central-MakeUs/Delta-front/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->